### PR TITLE
Change polytope type 

### DIFF
--- a/src/rounding.cpp
+++ b/src/rounding.cpp
@@ -24,6 +24,7 @@
 #include "preprocess/svd_rounding.hpp"
 #include "preprocess/max_inscribed_ellipsoid_rounding.hpp"
 #include "extractMatPoly.h"
+#include <stdio.h>
 
 template
 <
@@ -101,7 +102,16 @@ Rcpp::List rounding (Rcpp::Reference P,
     if(method.isNotNull()) {
         method_rcpp =  Rcpp::as<std::string>(method);
         if (method_rcpp.compare(std::string("max_ellipsoid")) == 0 && type != 1) {
-            Rcpp::exception("This method can not be used for V- or Z-polytopes!");
+            Rcpp::Rcout << "Warning: The method max_ellipsoid cannot be used for V- or Z-polytopes." << std::endl;
+            std::string changeType;
+            Rcpp::Rcout << "Do you want to convert the polytope type to Hpolytope (y/n)? ";
+            std::cin >> changeType;
+            if(changeType == 'y' || changeTyoe == 'Y'){
+                Rcpp::Rcout << "Polytope type changed to Hpolytope." << std::endl;
+                type = 1; //change the tope to Hpolytope
+            } else{
+                throw Rcpp::exception("This method can not be used for V- or Z-polytopes!");
+            }
         }
     }
 


### PR DESCRIPTION
Initially, if the polytope is not an H-polytope but the method is max_ellipsoid, an error is thrown saying that the max_ellipsoid is not applicable for V- or Z- polytopes. This change is made so that if the user entered the wrong polytope type by mistake but actually wants to use the max_ellipsoid method for H-polytope, the user gets an option to change it.

(This is a minor change in the Rcpp rounding function and does not require any additional modification to round_polytops.R, RcppExports.cpp or RcppExports.R)