### PR TITLE
Enable Windows big-object mode (-Wa,-mbig-obj) to avoid COFF section-limit build failures

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,6 @@
 PKG_CPPFLAGS=-Iexternal -Iexternal/lpSolve/src -Iexternal/minimum_ellipsoid -Ivolesti/include -Ivolesti/include/convex_bodies/spectrahedra
-PKG_CXXFLAGS= -lm -ldl -DBOOST_NO_AUTO_PTR -DDISABLE_NLP_ORACLES
+# Use big object format on Windows to avoid assembler section limits in template-heavy files.
+PKG_CXXFLAGS= -lm -ldl -DBOOST_NO_AUTO_PTR -DDISABLE_NLP_ORACLES -Wa,-mbig-obj
 
 PKG_LIBS=-Lexternal/lpSolve/src -llp_solve -Lexternal/PackedCSparse/qd -lqd $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 


### PR DESCRIPTION
**Solved :** https://github.com/GeomScale/Rvolesti/issues/31

-> Added a short explanatory comment and appended the assembler flag -Wa,-mbig-obj to PKG_CXXFLAGS in src/Makevars.win so Windows builds use big-object format.
-> The change targets only the Windows-specific Makevars.win to avoid affecting other platforms.

**Description**
-> Add Windows big-object assembler flag to prevent COFF section-limit failures

-> Enable -Wa,-mbig-obj in PKG_CXXFLAGS for template-heavy compilation units

-> Include explanatory comment documenting the purpose of the flag

-> Fix newline at end of file