### PR TITLE
Initial support for sparse matrix representation of H-polytopes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Version: 1.2.0
 Date: 2024-02-29
 Maintainer: Vissarion Fisikopoulos <vissarion.fisikopoulos@gmail.com>
 Depends: Rcpp (>= 0.12.17)
-Imports: methods, stats, Matrix
+Imports: methods, stats, Matrix, Rcpp
 LinkingTo: Rcpp, RcppEigen, BH
 Suggests: testthat
 Encoding: UTF-8

--- a/R/HpolytopeClass.R
+++ b/R/HpolytopeClass.R
@@ -26,7 +26,7 @@ Hpolytope <- setClass (
   
   # Defining slot type
   representation (
-    A = "matrix",
+    A = "ANY",
     b = "numeric",
     volume = "numeric",
     type = "character"

--- a/R/HpolytopeSparseClass.R
+++ b/R/HpolytopeSparseClass.R
@@ -9,9 +9,9 @@
 #'
 #'    \item{bineq}{An \eqn{m}-dimensional vector for the ineqaulities.}
 #'
-#'    \item{Aineq}{An \eqn{m'\times d} sparse numerical matrix for the equalities.}
+#'    \item{Aeq}{An m'×d sparse numerical matrix for the equalities.}
 #'
-#'    \item{bineq}{An \eqn{m'}-dimensional vector for the eqaulities.}
+#'    \item{beq}{An m'-dimensional vector for the equalities.}
 #'
 #'    \item{lb}{\eqn{d}-dimensional vector lb.}
 #'
@@ -20,6 +20,7 @@
 #'    \item{type}{A character with default value 'HpolytopeSparse', to declare the representation of the polytope.}
 #' }
 #'
+#' @import Matrix
 #' @examples
 #' library(Matrix)
 #' bineq=c(10,10,10,10,10)

--- a/src/sparse_hpolytope.cpp
+++ b/src/sparse_hpolytope.cpp
@@ -1,0 +1,23 @@
+// [[Rcpp::depends(RcppEigen)]]
+#include <RcppEigen.h>
+
+using namespace Rcpp;
+using Eigen::SparseMatrix;
+using Eigen::VectorXd;
+
+// [[Rcpp::export]]
+SEXP create_sparse_hpolytope(const SparseMatrix<double> &A,
+                             const VectorXd &b) {
+
+    // Get dimensions
+    int m = A.rows();
+    int n = A.cols();
+
+    // Proof that sparse matrix arrived correctly
+    return List::create(
+        Named("rows") = m,
+        Named("cols") = n,
+        Named("nonzeros") = A.nonZeros(),
+        Named("b_length") = b.size()
+    );
+}

--- a/tests/testthat/test-sparse.R
+++ b/tests/testthat/test-sparse.R
@@ -1,0 +1,12 @@
+library(Matrix)
+library(Rvolesti)
+
+test_that("Sparse Hpolytope works", {
+
+  A <- rsparsematrix(10, 5, density = 0.2)
+  b <- rep(1, 10)
+
+  P <- Hpolytope(A, b)
+
+  expect_true(inherits(P, "Hpolytope_sparse"))
+})


### PR DESCRIPTION
This PR introduces the initial infrastructure required to support sparse matrix representations of H-polytopes in Rvolesti. While the volesti C++ backend already supports sparse matrices, the R interface currently lacks a pathway for handling sparse inputs efficiently.
The changes focus on enabling R-to-C++ transfer of sparse matrices using RcppEigen and preparing the package for future integration with the sparse polytope backend.

## Changes

1- Updated S4 class definitions to allow sparse matrix storage where appropriate
2- Added dependency on the Matrix package for sparse matrix support
3- Linked RcppEigen to enable automatic conversion of R sparse matrices (e.g., `dgCMatrix`) to Eigen sparse matrices
4- Implemented a minimal C++ wrapper (`create_sparse_hpolytope`) to verify successful transfer of sparse matrices from R to C++
5- Added basic tests for sparse input handling

## Notes

1- This PR does not yet connect to the full volesti sparse polytope implementation; it establishes the foundational infrastructure required for that integration.
2- Existing functionality for dense H-polytopes remains unchanged.
3- Backward compatibility is preserved.

Supporting sparse matrices is important for high-dimensional polytopes where the constraint matrix is largely sparse. This can significantly improve memory usage and computational efficiency for large-scale problems.

## Future work will focus on:

1- Constructing volesti sparse polytope objects from the transferred matrices
2- Extending sampling and volume estimation functions to support sparse inputs
3- Performance validation against dense representations

## Related Issue

Closes/Relates to: #29 (Support sparse matrices to represent H-polytopes)

 Thank You!