### PR TITLE
Add count_linear_extensions() R function for approximating linear extensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Version: 1.2.0
 Date: 2024-02-29
 Maintainer: Vissarion Fisikopoulos <vissarion.fisikopoulos@gmail.com>
 Depends: Rcpp (>= 0.12.17)
-Imports: methods, stats, Matrix
+Imports: methods, stats, Matrix, Rcpp
 LinkingTo: Rcpp, RcppEigen, BH
 Suggests: testthat
 Encoding: UTF-8

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(compute_indicators)
 export(copula)
+export(count_linear_extensions)
 export(dinvweibull_with_loc)
 export(direct_sampling)
 export(ess)

--- a/R/HpolytopeClass.R
+++ b/R/HpolytopeClass.R
@@ -26,7 +26,7 @@ Hpolytope <- setClass (
   
   # Defining slot type
   representation (
-    A = "matrix",
+    A = "ANY",
     b = "numeric",
     volume = "numeric",
     type = "character"

--- a/R/HpolytopeSparseClass.R
+++ b/R/HpolytopeSparseClass.R
@@ -9,9 +9,9 @@
 #'
 #'    \item{bineq}{An \eqn{m}-dimensional vector for the ineqaulities.}
 #'
-#'    \item{Aineq}{An \eqn{m'\times d} sparse numerical matrix for the equalities.}
+#'    \item{Aeq}{An m'×d sparse numerical matrix for the equalities.}
 #'
-#'    \item{bineq}{An \eqn{m'}-dimensional vector for the eqaulities.}
+#'    \item{beq}{An m'-dimensional vector for the equalities.}
 #'
 #'    \item{lb}{\eqn{d}-dimensional vector lb.}
 #'
@@ -20,6 +20,7 @@
 #'    \item{type}{A character with default value 'HpolytopeSparse', to declare the representation of the polytope.}
 #' }
 #'
+#' @import Matrix
 #' @examples
 #' library(Matrix)
 #' bineq=c(10,10,10,10,10)

--- a/R/count_linear_extensions.R
+++ b/R/count_linear_extensions.R
@@ -1,0 +1,50 @@
+#' Count Linear Extensions of a Partial Order
+#'
+#' Approximates the number of linear extensions of a partial order (poset)
+#' using volume estimation of the corresponding order polytope.
+#' Uses the identity: #LE = n! * Vol(OrderPolytope).
+#'
+#' @param n Integer. Number of elements in the poset (labeled 0 to n-1).
+#' @param relations A matrix with 2 columns, where each row (i,j) represents
+#'   the order relation a_i <= a_j. For an antichain (no relations), pass
+#'   \code{matrix(ncol=2, nrow=0)}.
+#' @param algorithm String. Volume approximation algorithm:
+#'   \code{"CB"} (Cooling Balls, default),
+#'   \code{"CG"} (Cooling Gaussians), or
+#'   \code{"SOB"} (Sequence of Balls).
+#' @param error Numeric. Upper bound for the approximation error (default 0.1).
+#' @param walk_length Integer. Number of steps per random walk (default 1).
+#'
+#' @return A list with elements:
+#' \describe{
+#'   \item{linear_extensions}{Approximate count of linear extensions}
+#'   \item{volume}{Approximate volume of the order polytope}
+#'   \item{dimension}{Number of elements in the poset}
+#' }
+#'
+#' @references
+#' Stanley, R.P. (1986). Two Poset Polytopes.
+#' \emph{Discrete & Computational Geometry}, 1, 9-23.
+#'
+#' @examples
+#' \dontrun{
+#' # Chain: exactly 1 linear extension
+#' count_linear_extensions(4, rbind(c(0,1), c(1,2), c(2,3)))
+#'
+#' # Antichain: exactly n! = 24 linear extensions
+#' count_linear_extensions(4, matrix(ncol=2, nrow=0))
+#' }
+#'
+#' @export
+count_linear_extensions <- function(n, relations = matrix(ncol=2, nrow=0),
+                                     algorithm = "CB", error = 0.1,
+                                     walk_length = 1L) {
+
+    if (!is.matrix(relations)) {
+        relations <- matrix(as.integer(relations), ncol = 2, byrow = TRUE)
+    }
+    storage.mode(relations) <- "integer"
+
+    .Call(`_volesti_count_linear_extensions`,
+          as.integer(n), relations, algorithm, error, as.integer(walk_length))
+}

--- a/src/count_linear_extensions.cpp
+++ b/src/count_linear_extensions.cpp
@@ -1,0 +1,112 @@
+// [[Rcpp::depends(BH)]]
+
+// VolEsti (volume computation and sampling library)
+// Licensed under GNU LGPL.3, see LICENCE file
+
+// Count linear extensions of a partial order via volume estimation
+// of the corresponding order polytope.
+
+#include <Rcpp.h>
+#include <RcppEigen.h>
+#include <boost/random.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+
+#include "cartesian_geom/cartesian_kernel.h"
+#include "convex_bodies/orderpolytope.h"
+#include "misc/poset.h"
+#include "random_walks/random_walks.hpp"
+#include "volume/volume_sequence_of_balls.hpp"
+#include "volume/volume_cooling_gaussians.hpp"
+#include "volume/volume_cooling_balls.hpp"
+
+
+//' Count the number of linear extensions of a partial order
+//'
+//' Uses volume approximation of the corresponding order polytope.
+//' The number of linear extensions equals n! * Vol(OrderPolytope).
+//'
+//' @param n Integer. Number of elements in the poset (elements are 0 to n-1).
+//' @param relations A matrix with 2 columns. Each row (i, j) represents the relation a_i <= a_j.
+//' @param algorithm String. Volume algorithm to use: "CB" (Cooling Balls, default), "CG" (Cooling Gaussians), or "SOB" (Sequence of Balls).
+//' @param error Numeric. Upper bound for volume approximation error (default: 0.1).
+//' @param walk_length Integer. Walk length for the random walk (default: 1).
+//'
+//' @return A list with:
+//' \describe{
+//'   \item{linear_extensions}{Approximate number of linear extensions}
+//'   \item{volume}{Approximate volume of the order polytope}
+//'   \item{dimension}{Number of elements in the poset}
+//' }
+//'
+//' @examples
+//' # Chain: a0 <= a1 <= a2 <= a3 (exactly 1 linear extension)
+//' result <- count_linear_extensions(4, rbind(c(0,1), c(1,2), c(2,3)))
+//'
+//' # Antichain: no relations (exactly 4! = 24 linear extensions)
+//' result <- count_linear_extensions(4, matrix(ncol=2, nrow=0))
+//'
+//' @export
+// [[Rcpp::export]]
+Rcpp::List count_linear_extensions(int n,
+                                    Rcpp::Nullable<Rcpp::IntegerMatrix> relations = R_NilValue,
+                                    Rcpp::Nullable<std::string> algorithm = R_NilValue,
+                                    double error = 0.1,
+                                    int walk_length = 1)
+{
+    typedef double NT;
+    typedef Cartesian<NT> Kernel;
+    typedef typename Kernel::Point Point;
+    typedef BoostRandomNumberGenerator<boost::mt19937, NT> RNGType;
+    typedef OrderPolytope<Point> OrderPoly;
+    typedef typename OrderPoly::VT VT;
+    typedef typename OrderPoly::MT MT;
+
+    // Build the poset
+    typedef typename Poset::RT RT;
+    typedef typename Poset::RV RV;
+
+    RV order_relations;
+    if (relations.isNotNull()) {
+        Rcpp::IntegerMatrix rel_mat(relations);
+        for (int i = 0; i < rel_mat.nrow(); ++i) {
+            order_relations.push_back(RT(rel_mat(i, 0), rel_mat(i, 1)));
+        }
+    }
+
+    Poset poset(n, order_relations);
+    OrderPoly OP(poset);
+
+    unsigned int d = OP.dimension();
+    RNGType rng(d);
+
+    // Determine algorithm
+    std::string algo = "CB";
+    if (algorithm.isNotNull()) {
+        algo = Rcpp::as<std::string>(algorithm);
+    }
+
+    // Compute volume
+    NT volume;
+    if (algo == "SOB" || algo == "sob") {
+        unsigned int wl = (walk_length == 1) ? (10 + d / 10) : walk_length;
+        volume = volume_sequence_of_balls<CDHRWalk, RNGType>(OP, rng, error, wl);
+    } else if (algo == "CG" || algo == "cg") {
+        volume = volume_cooling_gaussians<GaussianCDHRWalk, RNGType>(OP, rng, error, walk_length);
+    } else {
+        volume = volume_cooling_balls<CDHRWalk, RNGType>(OP, rng, error, walk_length).second;
+    }
+
+    // Compute n! * volume
+    NT le_count = volume;
+    for (int i = d; i > 1; --i) {
+        le_count *= NT(i);
+    }
+
+    return Rcpp::List::create(
+        Rcpp::Named("linear_extensions") = le_count,
+        Rcpp::Named("volume") = volume,
+        Rcpp::Named("dimension") = d
+    );
+}

--- a/src/sparse_hpolytope.cpp
+++ b/src/sparse_hpolytope.cpp
@@ -1,0 +1,23 @@
+// [[Rcpp::depends(RcppEigen)]]
+#include <RcppEigen.h>
+
+using namespace Rcpp;
+using Eigen::SparseMatrix;
+using Eigen::VectorXd;
+
+// [[Rcpp::export]]
+SEXP create_sparse_hpolytope(const SparseMatrix<double> &A,
+                             const VectorXd &b) {
+
+    // Get dimensions
+    int m = A.rows();
+    int n = A.cols();
+
+    // Proof that sparse matrix arrived correctly
+    return List::create(
+        Named("rows") = m,
+        Named("cols") = n,
+        Named("nonzeros") = A.nonZeros(),
+        Named("b_length") = b.size()
+    );
+}

--- a/tests/testthat/test-sparse.R
+++ b/tests/testthat/test-sparse.R
@@ -1,0 +1,12 @@
+library(Matrix)
+library(Rvolesti)
+
+test_that("Sparse Hpolytope works", {
+
+  A <- rsparsematrix(10, 5, density = 0.2)
+  b <- rep(1, 10)
+
+  P <- Hpolytope(A, b)
+
+  expect_true(inherits(P, "Hpolytope_sparse"))
+})


### PR DESCRIPTION
Adds an R interface for counting linear extensions of partial orders via OrderPolytope
volume estimation. Depends on the corresponding volesti C++ changes.

(1) Changes
- **[src/count_linear_extensions.cpp](cci:7://file:///c:/Users/chinm/Downloads/GSOC-P4-2/Rvolesti/src/count_linear_extensions.cpp:0:0-0:0)** — Rcpp bridge wrapping the C++ OrderPolytope volume API
- **[R/count_linear_extensions.R](cci:7://file:///c:/Users/chinm/Downloads/GSOC-P4-2/Rvolesti/R/count_linear_extensions.R:0:0-0:0)** — R wrapper function with roxygen2 documentation
- **[NAMESPACE](cci:7://file:///c:/Users/chinm/Downloads/GSOC-P4-2/Rvolesti/NAMESPACE:0:0-0:0)** — Exported [count_linear_extensions](cci:1://file:///c:/Users/chinm/Downloads/GSOC-P4-2/volesti/include/volume/count_linear_extensions.hpp:40:0-78:1)

(2)Usage
```r
(i)Chain: exactly 1 linear extension
count_linear_extensions(4, rbind(c(0,1), c(1,2), c(2,3)))
(ii)Antichain: exactly 4! = 24 linear extensions
count_linear_extensions(4, matrix(ncol=2, nrow=0))
(iii)With algorithm choice
count_linear_extensions(4, rbind(c(0,1), c(0,2)), algorithm = "CG")