### PR TITLE
Expose rounding routines: fix max_ellipsoid validation and documentation

### DIFF
--- a/R/round_polytope.R
+++ b/R/round_polytope.R
@@ -5,7 +5,7 @@
 #' @param P A convex polytope. It is an object from class (a) Hpolytope or (b) Vpolytope or (c) Zonotope.
 #' @param settings Optional. A list of settings.
 #' \describe{
-#' \item{\code{method}}{The method to use for rounding, a) \code{'min_ellipsoid'} for the method based on mimimmum volume enclosing ellipsoid of a dataset, b) \code{'max_ellipsoid'} for the method based on maximum volume enclosed ellipsoid, (c) \code{'isotropy'} for the method based on svd decomposition. The default method is \code{'mee'} for all the representations.}
+#' \item{\code{method}}{The method to use for rounding, a) \code{'min_ellipsoid'} for the method based on minimum volume enclosing ellipsoid of a dataset, b) \code{'max_ellipsoid'} for the method based on maximum volume enclosed ellipsoid (H-polytopes only), c) \code{'isotropy'} for the method based on svd decomposition. The default method is \code{'isotropy'} for all the representations.}
 #' \item{\code{seed}}{Optional. A fixed seed for the number generator.}
 #' }
 #'

--- a/src/rounding.cpp
+++ b/src/rounding.cpp
@@ -101,7 +101,7 @@ Rcpp::List rounding (Rcpp::Reference P,
     if(method.isNotNull()) {
         method_rcpp =  Rcpp::as<std::string>(method);
         if (method_rcpp.compare(std::string("max_ellipsoid")) == 0 && type != 1) {
-            Rcpp::exception("This method can not be used for V- or Z-polytopes!");
+            throw Rcpp::exception("This method can not be used for V- or Z-polytopes!");
         }
     }
 


### PR DESCRIPTION
Expose rounding routines: fix max_ellipsoid validation and documentation

Resolves #30 - Expose new rounding routines

**Changes:**

1. **Fix missing throw statement** (src/rounding.cpp)
   - Add `throw` keyword to max_ellipsoid validation error
   - Ensures proper error handling when max_ellipsoid is used on V-polytopes/Zonotopes

2. **Clarify rounding method restrictions** (R/round_polytope.R)
   - Document that max_ellipsoid only works with H-polytopes
   - Fix typos: "mimimmum" → "minimum", "mee" → "isotropy"
   - Update default method documentation

**Methods supported:**
- `min_ellipsoid`: Works on all polytope types (H, V, Zonotope)
- `max_ellipsoid`: H-polytopes only (inscribed ellipsoid)
- `isotropy`: Works on all polytope types (SVD-based)

**Result:** All rounding routines now properly exposed and documented